### PR TITLE
Fix breaking changes in Bunkum v3.3.3

### DIFF
--- a/SoundShapesServer/Database/GameDatabaseProvider.cs
+++ b/SoundShapesServer/Database/GameDatabaseProvider.cs
@@ -41,6 +41,12 @@ public class GameDatabaseProvider : RealmDatabaseProvider<GameDatabaseContext>
 
     protected override string Filename => "database.realm";
 
+    public override void Warmup()
+    {
+        using GameDatabaseContext context = GetContext();
+        _ = context.GetAdminUser();
+    }
+
     protected override void Migrate(Migration migration, ulong oldVersion)
     {
         IQueryable<dynamic> oldLikeRelations = migration.OldRealm.DynamicApi.All("LevelLikeRelation");

--- a/SoundShapesServer/SoundShapesServer.csproj
+++ b/SoundShapesServer/SoundShapesServer.csproj
@@ -9,9 +9,9 @@
 
     <ItemGroup>
       <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
-      <PackageReference Include="Bunkum" Version="3.3.1" />
+      <PackageReference Include="Bunkum" Version="3.3.3" />
       <PackageReference Include="Bunkum.ProfanityFilter" Version="1.0.0" />
-      <PackageReference Include="Bunkum.RealmDatabase" Version="3.1.3" />
+      <PackageReference Include="Bunkum.RealmDatabase" Version="3.1.4" />
       <PackageReference Include="HtmlAgilityPack" Version="1.11.46" />
       <PackageReference Include="HttpMultipartParser" Version="8.1.0" />
       <PackageReference Include="NPTicket" Version="2.0.0" />


### PR DESCRIPTION
With the introduction of health checks, some breaking changes were made to database providers. This PR fixes those and brings `Bunkum` up to v3.3.3 and `Bunkum.RealmDatabase` to v3.1.4.

Additionally, this brings in support for warmups.